### PR TITLE
Add new Details Screen with Jetpack Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The goal of this sample app is to demonstrate my technical ability and preferred
 
 * [RealSnapshotRepository](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt) and it's [test](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/test/java/com/scottyab/challenge/data/RealSnapshotRepositoryTest.kt)
 * [SnapshotTracker](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/main/java/com/scottyab/challenge/domain/SnapshotTracker.kt) and it's [test](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/test/java/com/scottyab/challenge/domain/SnapshotTrackerTest.kt)
-* [SnapshotViewModel](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsViewModel.kt) and it's [test](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/test/java/com/scottyab/challenge/presentation/snapshots/SnapshotsViewModelTest.kt) 
+* [SnapshotViewModel](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/main/java/com/scottyab/challenge/presentation/snapshots/DetailsViewModel.kt) and it's [test](https://github.com/scottyab/sample-location-based-image-tracker/blob/main/app/src/test/java/com/scottyab/challenge/presentation/snapshots/SnapshotsViewModelTest.kt) 
 
 
 ## Brief: Location based image tracker
@@ -110,10 +110,11 @@ Some notes how I might look to enhance this further outside of the requirements
 
 #### Additional ideas to showcase skills/experience 
 
-* Automated version generation 
+* Automated version code and number generation
 * CI integration, run junit tests on PR
- * Create beta pipeline to upload to appetize.io/appcircle 
-* CD integration with publishing to Play store triggered on tag
+ * Create beta pipeline to upload to appetize.io/appcircle
+ * Tags to trigger release build and upload of Github version
+* CD integration with publishing to Play store (triggered on tag)
 
 
  

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,16 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 
 android {
-    compileSdkVersion 33
-
     defaultConfig {
         applicationId "com.scottyab.challenge"
+        compileSdkVersion = 34
         minSdkVersion 26
-        targetSdkVersion 33
-        versionCode 2
-        versionName "1.1"
+        targetSdkVersion 34
+        versionCode 3
+        versionName "1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "FLICKR_API_KEY", "\"db4d8e7389523f8b31a0d40e9066c72d\"")
@@ -20,11 +19,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildFeatures {
+        compose true
         viewBinding true
     }
 
@@ -36,6 +36,14 @@ android {
             keyAlias "sample"
             keyPassword "sample"
         }
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
     }
 
     buildTypes {
@@ -64,57 +72,69 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    namespace 'com.scottyab.challenge'
 
 }
 
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.6.0'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
-    implementation 'androidx.databinding:viewbinding:7.3.1'
-    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation platform('androidx.compose:compose-bom:2024.01.00')
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation 'io.coil-kt:coil-compose:2.2.2'
+    implementation "androidx.compose.runtime:runtime-livedata:1.6.0"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+    implementation 'androidx.compose.material3:material3'
+
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.7.0'
+    implementation 'androidx.databinding:viewbinding:8.2.2'
+    implementation 'com.google.android.gms:play-services-location:21.1.0'
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
     implementation("io.coil-kt:coil:2.2.2")
 
-    implementation "io.insert-koin:koin-android:3.2.2"
+    implementation "io.insert-koin:koin-android:3.4.3"
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // DB
-    implementation "androidx.room:room-runtime:2.5.0"
-    kapt "androidx.room:room-compiler:2.5.0"
-    implementation "androidx.room:room-ktx:2.5.0"
+    implementation "androidx.room:room-runtime:2.6.1"
+    ksp "androidx.room:room-compiler:2.6.1"
+    implementation "androidx.room:room-ktx:2.6.1"
 
     // Networking
-    implementation 'com.squareup.moshi:moshi:1.12.0'
+    implementation 'com.squareup.moshi:moshi:1.15.0'
     implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
-    implementation 'com.squareup.moshi:moshi-adapters:1.11.0'
+    implementation 'com.squareup.moshi:moshi-adapters:1.15.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
 
     // debug only
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
 
     // Tests
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'org.mockito:mockito-inline:3.12.2'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation "io.insert-koin:koin-test-junit4:3.2.2"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1"
-    testImplementation "io.insert-koin:koin-test:3.2.2"
-    testImplementation "io.insert-koin:koin-test-junit4:3.2.2"
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
+    testImplementation "io.insert-koin:koin-test-junit4:3.4.3"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
+    testImplementation "io.insert-koin:koin-test:3.4.3"
+    testImplementation "io.insert-koin:koin-test-junit4:3.4.3"
     testImplementation 'app.cash.turbine:turbine:0.12.1'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.scottyab.challenge">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
@@ -35,6 +35,12 @@
             android:launchMode="singleTask"
             android:exported="true">
         </activity>
+
+        <activity
+            android:name="com.scottyab.challenge.presentation.details.DetailsActivity"
+            android:exported="true">
+        </activity>
+
 
         <receiver android:name="com.scottyab.challenge.presentation.snapshots.SnapshotTrackerBroadcastReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
@@ -17,7 +17,7 @@ class RealSnapshotRepository(
     private val flickrService: FlickrService,
     private val snapshotMapper: SnapshotMapper,
     private val photoMapper: PhotoMapper,
-    private val snapshotDao: SnapshotDao,
+    private val snapshotDao: SnapshotDao
 ) : SnapshotRepository {
     override fun getSnapshots(activityId: String): Flow<List<Snapshot>> =
         snapshotDao.observeSnapshots(activityId).map(snapshotMapper::toDomain)
@@ -26,7 +26,7 @@ class RealSnapshotRepository(
 
     override suspend fun addSnapshot(
         activityId: String,
-        location: Location,
+        location: Location
     ) {
         try {
             val photos = downloadPhotos(location)
@@ -46,7 +46,7 @@ class RealSnapshotRepository(
      */
     private fun findUniquePhoto(
         activityId: String,
-        photos: List<Photo>,
+        photos: List<Photo>
     ): Photo? {
         if (photos.isEmpty()) return null
 

--- a/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
@@ -17,13 +17,17 @@ class RealSnapshotRepository(
     private val flickrService: FlickrService,
     private val snapshotMapper: SnapshotMapper,
     private val photoMapper: PhotoMapper,
-    private val snapshotDao: SnapshotDao
+    private val snapshotDao: SnapshotDao,
 ) : SnapshotRepository {
-
     override fun getSnapshots(activityId: String): Flow<List<Snapshot>> =
         snapshotDao.observeSnapshots(activityId).map(snapshotMapper::toDomain)
 
-    override suspend fun addSnapshot(activityId: String, location: Location) {
+    override suspend fun getSnapShot(snapshotId: String): Snapshot = snapshotMapper.toDomain(snapshotDao.getSnapshot(snapshotId))
+
+    override suspend fun addSnapshot(
+        activityId: String,
+        location: Location,
+    ) {
         try {
             val photos = downloadPhotos(location)
             // if there is not a unique photo skip adding it
@@ -40,7 +44,10 @@ class RealSnapshotRepository(
     /**
      * @return the first Photo from the list that is not already have saved in the DB
      */
-    private fun findUniquePhoto(activityId: String, photos: List<Photo>): Photo? {
+    private fun findUniquePhoto(
+        activityId: String,
+        photos: List<Photo>,
+    ): Photo? {
         if (photos.isEmpty()) return null
 
         val exitingPhotoIds = snapshotDao.getSnapshots(activityId).map { it.photoId }

--- a/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
@@ -21,9 +21,9 @@ import java.time.LocalDateTime
             entity = ActivityDb::class,
             parentColumns = ["id"],
             childColumns = ["activity_id"],
-            onDelete = ForeignKey.CASCADE
-        )
-    ]
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
 )
 data class SnapshotDb(
     @PrimaryKey
@@ -37,17 +37,19 @@ data class SnapshotDb(
     @ColumnInfo(name = "created_at")
     val createdAt: LocalDateTime = nowUTC(),
     val latitude: String,
-    val longitude: String
+    val longitude: String,
 )
 
 @Dao
 interface SnapshotDao {
-
     @Query("select * from Snapshot WHERE activity_id=:activityId ORDER BY datetime(Snapshot.created_at) DESC")
     fun observeSnapshots(activityId: String): Flow<List<SnapshotDb>>
 
     @Query("select * from Snapshot WHERE activity_id=:activityId ORDER BY photoId")
     fun getSnapshots(activityId: String): List<SnapshotDb>
+
+    @Query("select * from Snapshot WHERE photoId=:photoId")
+    fun getSnapshot(photoId: String): SnapshotDb
 
     @Insert(onConflict = ABORT)
     suspend fun insert(snapshot: SnapshotDb)

--- a/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
@@ -21,9 +21,9 @@ import java.time.LocalDateTime
             entity = ActivityDb::class,
             parentColumns = ["id"],
             childColumns = ["activity_id"],
-            onDelete = ForeignKey.CASCADE,
-        ),
-    ],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
 )
 data class SnapshotDb(
     @PrimaryKey
@@ -37,7 +37,7 @@ data class SnapshotDb(
     @ColumnInfo(name = "created_at")
     val createdAt: LocalDateTime = nowUTC(),
     val latitude: String,
-    val longitude: String,
+    val longitude: String
 )
 
 @Dao

--- a/app/src/main/java/com/scottyab/challenge/data/datasource/location/RealLocationProvider.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/datasource/location/RealLocationProvider.kt
@@ -3,7 +3,6 @@ package com.scottyab.challenge.data.datasource.location
 import android.content.Context
 import com.scottyab.challenge.domain.model.Location
 import com.scottyab.challenge.presentation.common.AppCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/app/src/main/java/com/scottyab/challenge/di/Modules.kt
+++ b/app/src/main/java/com/scottyab/challenge/di/Modules.kt
@@ -71,7 +71,7 @@ val networkModule =
                         if (BuildConfig.DEBUG) {
                             setLevel(HttpLoggingInterceptor.Level.BASIC)
                         }
-                    },
+                    }
                 ).build()
         }
 
@@ -95,7 +95,7 @@ val domainModule =
                 flickrService = get(),
                 snapshotMapper = get(),
                 snapshotDao = get(),
-                photoMapper = get(),
+                photoMapper = get()
             )
         }
         factory { SnapshotMapper(idGenerator = get()) }
@@ -106,27 +106,27 @@ val domainModule =
             RealActivityRepository(
                 activityMapper = get(),
                 activityDao = get(),
-                idGenerator = get(),
+                idGenerator = get()
             )
         }
 
         factory {
             NewLocationUsecase(
                 snapshotRepository = get(),
-                locationCalculator = get(),
+                locationCalculator = get()
             )
         }
 
         factory {
             StopActivityUsecase(
-                activityRepository = get(),
+                activityRepository = get()
             )
         }
 
         factory {
             StartActivityUsecase(
                 activityNameGenerator = get(),
-                activityRepository = get(),
+                activityRepository = get()
             )
         }
 
@@ -136,7 +136,7 @@ val domainModule =
                 newLocationUsecase = get(),
                 startActivityUsecase = get(),
                 stopActivityUsecase = get(),
-                appCoroutineScope = get(),
+                appCoroutineScope = get()
             )
         }
     }
@@ -151,13 +151,13 @@ val dataModule =
             LocationServiceNotificationHelper(
                 context = androidContext(),
                 androidResources = get(),
-                notificationManager = get(),
+                notificationManager = get()
             )
         }
         single {
             RealLocationProvider(
                 context = androidContext(),
-                appCoroutineScope = get(),
+                appCoroutineScope = get()
             )
         }
 
@@ -166,7 +166,7 @@ val dataModule =
                 SampleLocationProvider(
                     context = androidContext(),
                     moshi = get(),
-                    appCoroutineScope = get(),
+                    appCoroutineScope = get()
                 )
             } else {
                 get<RealLocationProvider>()
@@ -181,12 +181,12 @@ val presentationModule =
             SnapshotsViewModel(
                 snapshotRepository = get(),
                 snapshotUiMapper = get(),
-                snapshotTracker = get(),
+                snapshotTracker = get()
             )
         }
         viewModel {
             ActivitiesViewModel(
-                activityRepository = get(),
+                activityRepository = get()
             )
         }
 
@@ -194,7 +194,7 @@ val presentationModule =
             DetailsViewModel(
                 snapshotRepository = get(),
                 snapshotUiMapper = get(),
-                snapshotId = snapshotId,
+                snapshotId = snapshotId
             )
         }
     }

--- a/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
@@ -5,10 +5,14 @@ import com.scottyab.challenge.domain.model.Snapshot
 import kotlinx.coroutines.flow.Flow
 
 interface SnapshotRepository {
-
     fun getSnapshots(activityId: String): Flow<List<Snapshot>>
 
-    suspend fun addSnapshot(activityId: String, location: Location)
+    suspend fun addSnapshot(
+        activityId: String,
+        location: Location,
+    )
+
+    suspend fun getSnapShot(snapshotId: String): Snapshot
 
     /** TODO remove this as it's not needed as we deal with this on the activity level **/
     suspend fun reset(activityId: String)

--- a/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
@@ -9,7 +9,7 @@ interface SnapshotRepository {
 
     suspend fun addSnapshot(
         activityId: String,
-        location: Location,
+        location: Location
     )
 
     suspend fun getSnapShot(snapshotId: String): Snapshot

--- a/app/src/main/java/com/scottyab/challenge/domain/SnapshotTracker.kt
+++ b/app/src/main/java/com/scottyab/challenge/domain/SnapshotTracker.kt
@@ -6,8 +6,8 @@ import com.scottyab.challenge.domain.model.TrackingState
 import com.scottyab.challenge.domain.usecase.NewLocationUsecase
 import com.scottyab.challenge.domain.usecase.NewLocationUsecaseResult
 import com.scottyab.challenge.domain.usecase.StartActivityUsecase
-import com.scottyab.challenge.domain.usecase.StopActivityUsecase
 import com.scottyab.challenge.domain.usecase.StartActivityUsecaseResult
+import com.scottyab.challenge.domain.usecase.StopActivityUsecase
 import com.scottyab.challenge.presentation.common.AppCoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/scottyab/challenge/presentation/activities/ActivitiesAdapter.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/activities/ActivitiesAdapter.kt
@@ -27,14 +27,13 @@ internal class ActivitiesAdapter(
     }
 
     class ActivityViewHolder(
-        private val binding: ListItemActivityBinding,
+        private val binding: ListItemActivityBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(
             activity: Activity,
             onActivitySelected: (item: Activity) -> Unit
         ) {
-
             binding.apply {
                 title.text = activity.title
                 root.throttledClick { onActivitySelected.invoke(activity) }

--- a/app/src/main/java/com/scottyab/challenge/presentation/common/SingleLiveEvent.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/common/SingleLiveEvent.kt
@@ -19,7 +19,7 @@ class SingleLiveEvent<T> : MutableLiveData<T>() {
     @MainThread
     override fun observe(
         owner: LifecycleOwner,
-        observer: Observer<in T>,
+        observer: Observer<in T>
     ) {
         if (hasActiveObservers()) {
             Timber.w(TAG, "Multiple observers registered but only one will be notified of changes.")

--- a/app/src/main/java/com/scottyab/challenge/presentation/common/SingleLiveEvent.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/common/SingleLiveEvent.kt
@@ -14,24 +14,21 @@ import java.util.concurrent.atomic.AtomicBoolean
  * From https://abhiappmobiledeveloper.medium.com/android-singleliveevent-of-livedata-for-ui-event-35d0c58512da
  */
 class SingleLiveEvent<T> : MutableLiveData<T>() {
-
     private val mPending = AtomicBoolean(false)
 
     @MainThread
-    override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
+    override fun observe(
+        owner: LifecycleOwner,
+        observer: Observer<in T>,
+    ) {
         if (hasActiveObservers()) {
             Timber.w(TAG, "Multiple observers registered but only one will be notified of changes.")
         } // Observe the internal MutableLiveData
-        super.observe(
-            owner,
-            object : Observer<T> {
-                override fun onChanged(t: T?) {
-                    if (mPending.compareAndSet(true, false)) {
-                        observer.onChanged(t)
-                    }
-                }
+        super.observe(owner) { t ->
+            if (mPending.compareAndSet(true, false)) {
+                observer.onChanged(t)
             }
-        )
+        }
     }
 
     @MainThread
@@ -46,7 +43,9 @@ class SingleLiveEvent<T> : MutableLiveData<T>() {
     @MainThread
     fun call() {
         setValue(null)
-    } companion object {
+    }
+
+    companion object {
         private val TAG = "SingleLiveEvent"
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
@@ -38,7 +38,7 @@ class DetailsActivity : ComponentActivity() {
 
         fun openIntentExisting(
             context: Context,
-            snapshotId: String,
+            snapshotId: String
         ) = openIntent(context).putExtra(EXTRA_SNAPSHOT_ID, snapshotId)
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
@@ -1,0 +1,44 @@
+package com.scottyab.challenge.presentation.details
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.livedata.observeAsState
+import com.scottyab.challenge.presentation.ui.SampleAppTheme
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
+
+class DetailsActivity : ComponentActivity() {
+    private val viewModel: DetailsViewModel by viewModel {
+        parametersOf(intent.getStringExtra(EXTRA_SNAPSHOT_ID))
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val uiState = viewModel.state.observeAsState(DetailsState()).value
+
+            if (uiState.gotoSnapshots) {
+                finish()
+            }
+
+            SampleAppTheme {
+                DetailsScreen(uiState, viewModel::handleUiEvent)
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_SNAPSHOT_ID = "EXTRA_SNAPSHOT_ID"
+
+        private fun openIntent(context: Context) = Intent(context, DetailsActivity::class.java)
+
+        fun openIntentExisting(
+            context: Context,
+            snapshotId: String,
+        ) = openIntent(context).putExtra(EXTRA_SNAPSHOT_ID, snapshotId)
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
@@ -1,0 +1,159 @@
+package com.scottyab.challenge.presentation.details
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import com.scottyab.challenge.R
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.ShareClick
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.SnackMessageShown
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.UpClick
+import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
+import com.scottyab.challenge.presentation.ui.SampleAppTheme
+import com.scottyab.challenge.presentation.ui.common.AppProgressIndicator
+import com.scottyab.challenge.presentation.ui.common.DefaultTopBar
+import java.time.LocalDateTime
+
+@Suppress("ktlint:standard:function-naming")
+@Composable
+fun DetailsScreen(
+    uiState: DetailsState,
+    uiEventReceiver: (DetailsUiEvent) -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            DefaultTopBar(
+                uiState.title,
+                onBackIconClick = { uiEventReceiver.invoke(UpClick) },
+            )
+        },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+    ) { padding ->
+        if (uiState.showSnackMessage) {
+            LaunchedEffect(scope, uiState.snackMessage, snackbarHostState) {
+                val result =
+                    snackbarHostState.showSnackbar(
+                        message = uiState.snackMessage,
+                        duration = SnackbarDuration.Short,
+                    )
+                when (result) {
+                    SnackbarResult.Dismissed -> uiEventReceiver.invoke(SnackMessageShown)
+                    SnackbarResult.ActionPerformed -> { // No-Op
+                    }
+                }
+            }
+        }
+
+        if (uiState.showLoading) {
+            AppProgressIndicator()
+        } else {
+            Column(
+                modifier =
+                Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+            ) {
+                Column(
+                    modifier =
+                    Modifier
+                        .verticalScroll(rememberScrollState())
+                        .weight(1f),
+                ) {
+                    // content goes here
+                    SnapShotDetailsComposable(
+                        snapshot = uiState.aSnapshot,
+                        shareClick = { uiEventReceiver.invoke(ShareClick(uiState.aSnapshot.imageUrl)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SnapShotDetailsComposable(
+    snapshot: SnapshotUi,
+    shareClick: () -> Unit,
+) {
+    Column(
+        modifier =
+        Modifier
+            .fillMaxSize()
+            .padding(4.dp),
+    ) {
+        SubcomposeAsyncImage(
+            model = snapshot.imageUrl,
+            contentDescription = stringResource(R.string.snapshot_image_cd),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        BasicText(text = snapshot.title, style = MaterialTheme.typography.headlineLarge)
+        BasicText(text = snapshot.recordedAtFormatted)
+        Button(
+            onClick = { shareClick.invoke() },
+            modifier =
+            Modifier
+                .padding(16.dp)
+                .align(Alignment.CenterHorizontally),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Share,
+                contentDescription = stringResource(R.string.details_share_button_cd),
+            )
+            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+            Text(stringResource(R.string.details_share_button))
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DetailsScreenPreview() {
+    val snapshotUi =
+        SnapshotUi(
+            id = "123",
+            title = "This is a title",
+            imageUrl = "",
+            recordedAt = LocalDateTime.now(),
+        )
+    val uiState =
+        DetailsState(
+            aSnapshot = snapshotUi,
+        )
+    SampleAppTheme {
+        DetailsScreen(uiState) {}
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
@@ -47,7 +47,7 @@ import java.time.LocalDateTime
 @Composable
 fun DetailsScreen(
     uiState: DetailsState,
-    uiEventReceiver: (DetailsUiEvent) -> Unit,
+    uiEventReceiver: (DetailsUiEvent) -> Unit
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -56,17 +56,17 @@ fun DetailsScreen(
         topBar = {
             DefaultTopBar(
                 uiState.title,
-                onBackIconClick = { uiEventReceiver.invoke(UpClick) },
+                onBackIconClick = { uiEventReceiver.invoke(UpClick) }
             )
         },
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0)
     ) { padding ->
         if (uiState.showSnackMessage) {
             LaunchedEffect(scope, uiState.snackMessage, snackbarHostState) {
                 val result =
                     snackbarHostState.showSnackbar(
                         message = uiState.snackMessage,
-                        duration = SnackbarDuration.Short,
+                        duration = SnackbarDuration.Short
                     )
                 when (result) {
                     SnackbarResult.Dismissed -> uiEventReceiver.invoke(SnackMessageShown)
@@ -83,18 +83,18 @@ fun DetailsScreen(
                 modifier =
                 Modifier
                     .padding(padding)
-                    .fillMaxSize(),
+                    .fillMaxSize()
             ) {
                 Column(
                     modifier =
                     Modifier
                         .verticalScroll(rememberScrollState())
-                        .weight(1f),
+                        .weight(1f)
                 ) {
                     // content goes here
                     SnapShotDetailsComposable(
                         snapshot = uiState.aSnapshot,
-                        shareClick = { uiEventReceiver.invoke(ShareClick(uiState.aSnapshot.imageUrl)) },
+                        shareClick = { uiEventReceiver.invoke(ShareClick(uiState.aSnapshot.imageUrl)) }
                     )
                 }
             }
@@ -105,19 +105,19 @@ fun DetailsScreen(
 @Composable
 fun SnapShotDetailsComposable(
     snapshot: SnapshotUi,
-    shareClick: () -> Unit,
+    shareClick: () -> Unit
 ) {
     Column(
         modifier =
         Modifier
             .fillMaxSize()
-            .padding(4.dp),
+            .padding(4.dp)
     ) {
         SubcomposeAsyncImage(
             model = snapshot.imageUrl,
             contentDescription = stringResource(R.string.snapshot_image_cd),
             contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth()
         )
 
         BasicText(text = snapshot.title, style = MaterialTheme.typography.headlineLarge)
@@ -127,11 +127,11 @@ fun SnapShotDetailsComposable(
             modifier =
             Modifier
                 .padding(16.dp)
-                .align(Alignment.CenterHorizontally),
+                .align(Alignment.CenterHorizontally)
         ) {
             Icon(
                 imageVector = Icons.Filled.Share,
-                contentDescription = stringResource(R.string.details_share_button_cd),
+                contentDescription = stringResource(R.string.details_share_button_cd)
             )
             Spacer(Modifier.size(ButtonDefaults.IconSpacing))
             Text(stringResource(R.string.details_share_button))
@@ -147,11 +147,11 @@ fun DetailsScreenPreview() {
             id = "123",
             title = "This is a title",
             imageUrl = "",
-            recordedAt = LocalDateTime.now(),
+            recordedAt = LocalDateTime.now()
         )
     val uiState =
         DetailsState(
-            aSnapshot = snapshotUi,
+            aSnapshot = snapshotUi
         )
     SampleAppTheme {
         DetailsScreen(uiState) {}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
@@ -1,0 +1,63 @@
+package com.scottyab.challenge.presentation.details
+
+import androidx.lifecycle.viewModelScope
+import com.scottyab.challenge.domain.SnapshotRepository
+import com.scottyab.challenge.presentation.common.BaseViewModel
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.ShareClick
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.SnackMessageShown
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.UpClick
+import com.scottyab.challenge.presentation.snapshots.SnapshotUiMapper
+import com.scottyab.challenge.presentation.snapshots.model.EMPTY_SNAPSHOT
+import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class DetailsViewModel(
+    private val snapshotRepository: SnapshotRepository,
+    private val snapshotUiMapper: SnapshotUiMapper,
+    private val snapshotId: String,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : BaseViewModel<DetailsState>(DetailsState()) {
+    init {
+        viewModelScope.launch {
+            val snapshot =
+                withContext(backgroundDispatcher) {
+                    snapshotUiMapper.toUi(snapshotRepository.getSnapShot(snapshotId))
+                }
+            setState { copy(aSnapshot = snapshot) }
+        }
+    }
+
+    fun handleUiEvent(detailsUiEvent: DetailsUiEvent) {
+        when (detailsUiEvent) {
+            is ShareClick -> handleShare(detailsUiEvent.url)
+            is SnackMessageShown -> setState { copy(snackMessage = "") }
+            is UpClick -> setState { copy(gotoSnapshots = true) }
+        }
+    }
+
+    private fun handleShare(url: String) {
+        setState { copy(snackMessage = "Sharing {$url}") }
+    }
+}
+
+data class DetailsState(
+    val aSnapshot: SnapshotUi = EMPTY_SNAPSHOT,
+    val showLoading: Boolean = false,
+    val snackMessage: String = "",
+    val gotoSnapshots: Boolean = false,
+) {
+    val isEmpty = aSnapshot == EMPTY_SNAPSHOT
+    val title = if (isEmpty) "" else "Details"
+    val showSnackMessage = snackMessage.isNotEmpty()
+}
+
+sealed interface DetailsUiEvent {
+    data object UpClick : DetailsUiEvent
+
+    data object SnackMessageShown : DetailsUiEvent
+
+    data class ShareClick(val url: String) : DetailsUiEvent
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
@@ -18,7 +18,7 @@ class DetailsViewModel(
     private val snapshotRepository: SnapshotRepository,
     private val snapshotUiMapper: SnapshotUiMapper,
     private val snapshotId: String,
-    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseViewModel<DetailsState>(DetailsState()) {
     init {
         viewModelScope.launch {
@@ -47,7 +47,7 @@ data class DetailsState(
     val aSnapshot: SnapshotUi = EMPTY_SNAPSHOT,
     val showLoading: Boolean = false,
     val snackMessage: String = "",
-    val gotoSnapshots: Boolean = false,
+    val gotoSnapshots: Boolean = false
 ) {
     val isEmpty = aSnapshot == EMPTY_SNAPSHOT
     val title = if (isEmpty) "" else "Details"

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotAdapter.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotAdapter.kt
@@ -12,11 +12,11 @@ import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
 
 internal class SnapshotAdapter(
     private val imageLoader: ImageLoader,
-    private val onItemClick: (item: SnapshotUi) -> Unit,
+    private val onItemClick: (item: SnapshotUi) -> Unit
 ) : ListAdapter<SnapshotUi, SnapshotAdapter.SnapshotViewHolder>(DIFF_CALLBACK) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
-        viewType: Int,
+        viewType: Int
     ): SnapshotViewHolder {
         val binding = ListItemSnapshotBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return SnapshotViewHolder(binding, imageLoader)
@@ -24,18 +24,18 @@ internal class SnapshotAdapter(
 
     override fun onBindViewHolder(
         holder: SnapshotViewHolder,
-        position: Int,
+        position: Int
     ) {
         holder.bind(snapshotUi1 = getItem(position), onSelected = onItemClick)
     }
 
     class SnapshotViewHolder(
         private val binding: ListItemSnapshotBinding,
-        private val imageLoader: ImageLoader,
+        private val imageLoader: ImageLoader
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(
             snapshotUi1: SnapshotUi,
-            onSelected: (snapshotUi: SnapshotUi) -> Unit,
+            onSelected: (snapshotUi: SnapshotUi) -> Unit
         ) {
             imageLoader.load(snapshotUi1.imageUrl, binding.snapshotImageview)
             // ensuring there's CD from a accessibility point of view
@@ -51,11 +51,11 @@ private val DIFF_CALLBACK =
     object : DiffUtil.ItemCallback<SnapshotUi>() {
         override fun areItemsTheSame(
             oldItem: SnapshotUi,
-            newItem: SnapshotUi,
+            newItem: SnapshotUi
         ) = oldItem.id == newItem.id
 
         override fun areContentsTheSame(
             oldItem: SnapshotUi,
-            newItem: SnapshotUi,
+            newItem: SnapshotUi
         ) = oldItem == newItem
     }

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotAdapter.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotAdapter.kt
@@ -12,38 +12,50 @@ import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
 
 internal class SnapshotAdapter(
     private val imageLoader: ImageLoader,
-    private val onItemClick: (item: SnapshotUi) -> Unit
+    private val onItemClick: (item: SnapshotUi) -> Unit,
 ) : ListAdapter<SnapshotUi, SnapshotAdapter.SnapshotViewHolder>(DIFF_CALLBACK) {
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SnapshotViewHolder {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): SnapshotViewHolder {
         val binding = ListItemSnapshotBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return SnapshotViewHolder(binding, imageLoader)
     }
 
-    override fun onBindViewHolder(holder: SnapshotViewHolder, position: Int) {
-        holder.bind(article = getItem(position), onArticleSelected = onItemClick)
+    override fun onBindViewHolder(
+        holder: SnapshotViewHolder,
+        position: Int,
+    ) {
+        holder.bind(snapshotUi1 = getItem(position), onSelected = onItemClick)
     }
 
     class SnapshotViewHolder(
         private val binding: ListItemSnapshotBinding,
-        private val imageLoader: ImageLoader
+        private val imageLoader: ImageLoader,
     ) : RecyclerView.ViewHolder(binding.root) {
-
-        fun bind(article: SnapshotUi, onArticleSelected: (snapshotUi: SnapshotUi) -> Unit) {
-            imageLoader.load(article.imageUrl, binding.snapshotImageview)
+        fun bind(
+            snapshotUi1: SnapshotUi,
+            onSelected: (snapshotUi: SnapshotUi) -> Unit,
+        ) {
+            imageLoader.load(snapshotUi1.imageUrl, binding.snapshotImageview)
             // ensuring there's CD from a accessibility point of view
-            binding.snapshotImageview.contentDescription = article.title
+            binding.snapshotImageview.contentDescription = snapshotUi1.title
             binding.root.throttledClick {
-                onArticleSelected.invoke(article)
+                onSelected.invoke(snapshotUi1)
             }
         }
     }
 }
 
-private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<SnapshotUi>() {
-    override fun areItemsTheSame(oldItem: SnapshotUi, newItem: SnapshotUi) =
-        oldItem.id == newItem.id
+private val DIFF_CALLBACK =
+    object : DiffUtil.ItemCallback<SnapshotUi>() {
+        override fun areItemsTheSame(
+            oldItem: SnapshotUi,
+            newItem: SnapshotUi,
+        ) = oldItem.id == newItem.id
 
-    override fun areContentsTheSame(oldItem: SnapshotUi, newItem: SnapshotUi) =
-        oldItem == newItem
-}
+        override fun areContentsTheSame(
+            oldItem: SnapshotUi,
+            newItem: SnapshotUi,
+        ) = oldItem == newItem
+    }

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
@@ -80,7 +80,7 @@ class SnapshotsActivity : AppCompatActivity() {
         val permissions =
             mutableListOf(
                 Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
             )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -100,7 +100,7 @@ class SnapshotsActivity : AppCompatActivity() {
 
     private fun bindView(
         snapshots: List<SnapshotUi>,
-        toggleButtonTextResId: Int,
+        toggleButtonTextResId: Int
     ) {
         adapter.submitList(snapshots)
         binding.snapshotsRecyclerview.smoothScrollToPosition(0)
@@ -115,10 +115,10 @@ class SnapshotsActivity : AppCompatActivity() {
                     startActivity(
                         DetailsActivity.openIntentExisting(
                             context = this,
-                            snapshotId = snapshot.id,
-                        ),
+                            snapshotId = snapshot.id
+                        )
                     )
-                },
+                }
             )
 
         binding.apply {
@@ -143,7 +143,7 @@ class SnapshotsActivity : AppCompatActivity() {
 
         fun openIntentExisting(
             context: Context,
-            activityId: String,
+            activityId: String
         ) = openIntent(context).putExtra(EXTRA_ACTIVITY_ID, activityId)
 
         fun openFromNotificationPendingIntent(context: Context) =
@@ -151,7 +151,7 @@ class SnapshotsActivity : AppCompatActivity() {
                 context,
                 OPEN_FROM_NOTIFICATION_RC,
                 openIntent(context),
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
@@ -13,16 +13,15 @@ import com.scottyab.challenge.databinding.ActivitySnapshotsListBinding
 import com.scottyab.challenge.presentation.common.ImageLoader
 import com.scottyab.challenge.presentation.common.SimpleThrottler
 import com.scottyab.challenge.presentation.common.action
-import com.scottyab.challenge.presentation.common.createShareIntent
 import com.scottyab.challenge.presentation.common.openAppSettings
 import com.scottyab.challenge.presentation.common.snack
 import com.scottyab.challenge.presentation.common.viewBinding
+import com.scottyab.challenge.presentation.details.DetailsActivity
 import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class SnapshotsActivity : AppCompatActivity() {
-
     private val binding by viewBinding(ActivitySnapshotsListBinding::inflate)
     private val imageLoader by inject<ImageLoader>()
     private val clickThrottler by inject<SimpleThrottler>()
@@ -30,19 +29,22 @@ class SnapshotsActivity : AppCompatActivity() {
 
     private lateinit var adapter: SnapshotAdapter
 
-    private val locationPermissionRequest = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-        when {
-            // todo more robust checking of all the permissions needed
-            permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
-                // request background location permission (needs to be a separate request)
-                checkBackgroundLocationPermission()
-            } else -> {
-                snack(getString(R.string.location_permission_denied_msg)) {
-                    action(getString(R.string.location_permission_denied_action)) { openAppSettings() }
+    private val locationPermissionRequest =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            when {
+                // todo more robust checking of all the permissions needed
+                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
+                    // request background location permission (needs to be a separate request)
+                    checkBackgroundLocationPermission()
+                }
+
+                else -> {
+                    snack(getString(R.string.location_permission_denied_msg)) {
+                        action(getString(R.string.location_permission_denied_action)) { openAppSettings() }
+                    }
                 }
             }
         }
-    }
 
     private val backgroundPermissionRequest =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -75,10 +77,11 @@ class SnapshotsActivity : AppCompatActivity() {
     }
 
     private fun checkRequiredPermissions() {
-        val permissions = mutableListOf(
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION
-        )
+        val permissions =
+            mutableListOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             permissions.add(Manifest.permission.POST_NOTIFICATIONS)
@@ -95,29 +98,28 @@ class SnapshotsActivity : AppCompatActivity() {
         }
     }
 
-    private fun bindView(snapshots: List<SnapshotUi>, toggleButtonTextResId: Int) {
+    private fun bindView(
+        snapshots: List<SnapshotUi>,
+        toggleButtonTextResId: Int,
+    ) {
         adapter.submitList(snapshots)
         binding.snapshotsRecyclerview.smoothScrollToPosition(0)
         binding.toolbar.menu.findItem(R.id.menu_toggle)?.title = getString(toggleButtonTextResId)
     }
 
     private fun initView() {
-        adapter = SnapshotAdapter(
-            imageLoader = imageLoader,
-            onItemClick = { snapshot ->
-                // This is added for demo purposes to show we could do something with onClick
-                // if this were real app this would be handled by VM or navigator
-                snack(snapshot.title) {
-                    action(getString(R.string.snapshot_share)) {
-                        startActivity(
-                            createShareIntent(
-                                getString(R.string.snapshot_share_text, snapshot.imageUrl)
-                            )
-                        )
-                    }
-                }
-            }
-        )
+        adapter =
+            SnapshotAdapter(
+                imageLoader = imageLoader,
+                onItemClick = { snapshot ->
+                    startActivity(
+                        DetailsActivity.openIntentExisting(
+                            context = this,
+                            snapshotId = snapshot.id,
+                        ),
+                    )
+                },
+            )
 
         binding.apply {
             setContentView(root)
@@ -139,14 +141,17 @@ class SnapshotsActivity : AppCompatActivity() {
 
         fun openIntent(context: Context) = Intent(context, SnapshotsActivity::class.java)
 
-        fun openIntentExisting(context: Context, activityId: String) =
-            openIntent(context).putExtra(EXTRA_ACTIVITY_ID, activityId)
+        fun openIntentExisting(
+            context: Context,
+            activityId: String,
+        ) = openIntent(context).putExtra(EXTRA_ACTIVITY_ID, activityId)
 
-        fun openFromNotificationPendingIntent(context: Context) = PendingIntent.getActivity(
-            context,
-            OPEN_FROM_NOTIFICATION_RC,
-            openIntent(context),
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
+        fun openFromNotificationPendingIntent(context: Context) =
+            PendingIntent.getActivity(
+                context,
+                OPEN_FROM_NOTIFICATION_RC,
+                openIntent(context),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/model/SnapshotUi.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/model/SnapshotUi.kt
@@ -1,20 +1,29 @@
 package com.scottyab.challenge.presentation.snapshots.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @Parcelize
 data class SnapshotUi(
     val id: String,
     val title: String,
     val imageUrl: String,
-    val recordedAt: LocalDateTime
-) : Parcelable
+    val recordedAt: LocalDateTime,
+) : Parcelable {
 
-val EMPTY_ARTICLE = SnapshotUi(
-    id = "",
-    imageUrl = "",
-    title = "",
-    recordedAt = LocalDateTime.now()
-)
+    @IgnoredOnParcel
+    val recordedAtFormatted: String =
+        recordedAt.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM))
+}
+
+val EMPTY_SNAPSHOT =
+    SnapshotUi(
+        id = "",
+        imageUrl = "",
+        title = "",
+        recordedAt = LocalDateTime.now(),
+    )

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/model/SnapshotUi.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/model/SnapshotUi.kt
@@ -12,7 +12,7 @@ data class SnapshotUi(
     val id: String,
     val title: String,
     val imageUrl: String,
-    val recordedAt: LocalDateTime,
+    val recordedAt: LocalDateTime
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -25,5 +25,5 @@ val EMPTY_SNAPSHOT =
         id = "",
         imageUrl = "",
         title = "",
-        recordedAt = LocalDateTime.now(),
+        recordedAt = LocalDateTime.now()
     )

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/Color.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/Color.kt
@@ -1,0 +1,12 @@
+package com.scottyab.challenge.presentation.ui
+
+import androidx.compose.ui.graphics.Color
+
+val AppBlue = Color(0xFF0A5787)
+val Secondary = Color(0xFF084A72)
+val VioletText = Color(0xFF140A97)
+val Grey200 = Color(0xFFF3F4F6)
+val Grey500 = Color(0xFF9A9A9A)
+val GreyText = Color(0xFF9A9A9A)
+val Black = Color(0xFF000000)
+val White = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
@@ -21,31 +21,31 @@ private val SampleAppColorScheme =
         onSecondary = White,
         onTertiary = Black,
         onBackground = Black,
-        onSurface = White,
+        onSurface = White
     )
 
 @Composable
 fun SampleAppTheme(
     colorScheme: ColorScheme = SampleAppColorScheme,
-    content: @Composable () -> Unit,
+    content: @Composable () -> Unit
 ) {
     MaterialTheme(
         colorScheme = colorScheme,
         typography =
-            Typography(
-                labelLarge =
-                    TextStyle(
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.Bold,
-                        lineHeight = 24.sp,
-                    ),
-                titleLarge =
-                    TextStyle(
-                        fontSize = 19.sp,
-                        fontWeight = FontWeight.W600,
-                        lineHeight = 24.sp,
-                    ),
+        Typography(
+            labelLarge =
+            TextStyle(
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 24.sp
             ),
-        content = content,
+            titleLarge =
+            TextStyle(
+                fontSize = 19.sp,
+                fontWeight = FontWeight.W600,
+                lineHeight = 24.sp
+            )
+        ),
+        content = content
     )
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
@@ -1,0 +1,51 @@
+package com.scottyab.challenge.presentation.ui
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+private val SampleAppColorScheme =
+    lightColorScheme(
+        primary = AppBlue,
+        secondary = Secondary,
+        tertiary = VioletText,
+        background = Grey200,
+        surface = Secondary,
+        surfaceVariant = Grey200,
+        onPrimary = White,
+        onSecondary = White,
+        onTertiary = Black,
+        onBackground = Black,
+        onSurface = White,
+    )
+
+@Composable
+fun SampleAppTheme(
+    colorScheme: ColorScheme = SampleAppColorScheme,
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography =
+            Typography(
+                labelLarge =
+                    TextStyle(
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        lineHeight = 24.sp,
+                    ),
+                titleLarge =
+                    TextStyle(
+                        fontSize = 19.sp,
+                        fontWeight = FontWeight.W600,
+                        lineHeight = 24.sp,
+                    ),
+            ),
+        content = content,
+    )
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
@@ -15,17 +15,17 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun AppProgressIndicator(
     modifier: Modifier = Modifier,
-    progressContentDescription: String = "Loading",
+    progressContentDescription: String = "Loading"
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier =
-            Modifier.fillMaxSize().semantics {
-                contentDescription = progressContentDescription
-            },
+        Modifier.fillMaxSize().semantics {
+            contentDescription = progressContentDescription
+        }
     ) {
         CircularProgressIndicator(
-            modifier = modifier.padding(8.dp).size(36.dp),
+            modifier = modifier.padding(8.dp).size(36.dp)
         )
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
@@ -1,0 +1,31 @@
+package com.scottyab.challenge.presentation.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AppProgressIndicator(
+    modifier: Modifier = Modifier,
+    progressContentDescription: String = "Loading",
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier.fillMaxSize().semantics {
+                contentDescription = progressContentDescription
+            },
+    ) {
+        CircularProgressIndicator(
+            modifier = modifier.padding(8.dp).size(36.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
@@ -1,0 +1,31 @@
+package com.scottyab.challenge.presentation.ui.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.scottyab.challenge.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DefaultTopBar(
+    titleText: String,
+    onBackIconClick: () -> Unit,
+) {
+    TopAppBar(
+        title = { Text(titleText) },
+        modifier = Modifier.fillMaxWidth(),
+        navigationIcon = {
+            IconButton(onClick = { onBackIconClick.invoke() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = stringResource(id = R.string.back_button))
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
@@ -17,7 +17,7 @@ import com.scottyab.challenge.R
 @Composable
 fun DefaultTopBar(
     titleText: String,
-    onBackIconClick: () -> Unit,
+    onBackIconClick: () -> Unit
 ) {
     TopAppBar(
         title = { Text(titleText) },
@@ -26,6 +26,6 @@ fun DefaultTopBar(
             IconButton(onClick = { onBackIconClick.invoke() }) {
                 Icon(Icons.Default.ArrowBack, contentDescription = stringResource(id = R.string.back_button))
             }
-        },
+        }
     )
 }

--- a/app/src/main/res/drawable/placeholder.xml
+++ b/app/src/main/res/drawable/placeholder.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,5 +23,9 @@
     <string name="cd_new_activity">Start new Activity</string>
     <string name="activities_title">Recorded Activities</string>
     <string name="activities_empty_text">No activities recorded, tap the plus Icon to start recording a new Activity.</string>
+    <string name="back_button">Back</string>
+    <string name="details_share_button">Share</string>
+    <string name="details_share_button_cd">Share</string>
+    <string name="snapshot_image_cd">Snapshot Image</string>
 
 </resources>

--- a/app/src/test/java/com/scottyab/challenge/domain/usecase/StartActivityUsecaseTest.kt
+++ b/app/src/test/java/com/scottyab/challenge/domain/usecase/StartActivityUsecaseTest.kt
@@ -9,7 +9,6 @@ import com.scottyab.challenge.domain.ActivityNameGenerator
 import com.scottyab.challenge.domain.ActivityRepository
 import com.scottyab.challenge.domain.model.Activity
 import com.scottyab.challenge.domain.usecase.StartActivityUsecaseResult.Success
-import com.scottyab.challenge.isInstanceOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Before
@@ -61,7 +60,7 @@ class StartActivityUsecaseTest {
             val result = sut.invoke()
 
             verify(activityRepository, never()).newActivity(any())
-            assertThat(result).isInstanceOf<Success> {
+            assertThat(result).isInstanceOf(Success::class.java) {
                 assertThat(it.activityId).isEqualTo(existingActivityId)
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.5.1"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+        classpath "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:1.9.22-1.0.17"
+
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,7 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jan 11 15:05:34 GMT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This is quick demo of how I would add a very basic details screen to view the details of a Snapshot using Jetpack Compose. 

Typically I'd break this PR into 2, the first being the target SDK, Java and dependency updates to support Compose and second to add the Details screen. 

