### PR TITLE
Added quick and simple details screen using Compose UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.scottyab.challenge">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
@@ -35,6 +35,12 @@
             android:launchMode="singleTask"
             android:exported="true">
         </activity>
+
+        <activity
+            android:name="com.scottyab.challenge.presentation.details.DetailsActivity"
+            android:exported="true">
+        </activity>
+
 
         <receiver android:name="com.scottyab.challenge.presentation.snapshots.SnapshotTrackerBroadcastReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/RealSnapshotRepository.kt
@@ -19,11 +19,15 @@ class RealSnapshotRepository(
     private val photoMapper: PhotoMapper,
     private val snapshotDao: SnapshotDao
 ) : SnapshotRepository {
-
     override fun getSnapshots(activityId: String): Flow<List<Snapshot>> =
         snapshotDao.observeSnapshots(activityId).map(snapshotMapper::toDomain)
 
-    override suspend fun addSnapshot(activityId: String, location: Location) {
+    override suspend fun getSnapShot(snapshotId: String): Snapshot = snapshotMapper.toDomain(snapshotDao.getSnapshot(snapshotId))
+
+    override suspend fun addSnapshot(
+        activityId: String,
+        location: Location
+    ) {
         try {
             val photos = downloadPhotos(location)
             // if there is not a unique photo skip adding it
@@ -40,7 +44,10 @@ class RealSnapshotRepository(
     /**
      * @return the first Photo from the list that is not already have saved in the DB
      */
-    private fun findUniquePhoto(activityId: String, photos: List<Photo>): Photo? {
+    private fun findUniquePhoto(
+        activityId: String,
+        photos: List<Photo>
+    ): Photo? {
         if (photos.isEmpty()) return null
 
         val exitingPhotoIds = snapshotDao.getSnapshots(activityId).map { it.photoId }

--- a/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
+++ b/app/src/main/java/com/scottyab/challenge/data/datasource/local/db/SnapshotDb.kt
@@ -42,12 +42,14 @@ data class SnapshotDb(
 
 @Dao
 interface SnapshotDao {
-
     @Query("select * from Snapshot WHERE activity_id=:activityId ORDER BY datetime(Snapshot.created_at) DESC")
     fun observeSnapshots(activityId: String): Flow<List<SnapshotDb>>
 
     @Query("select * from Snapshot WHERE activity_id=:activityId ORDER BY photoId")
     fun getSnapshots(activityId: String): List<SnapshotDb>
+
+    @Query("select * from Snapshot WHERE photoId=:photoId")
+    fun getSnapshot(photoId: String): SnapshotDb
 
     @Insert(onConflict = ABORT)
     suspend fun insert(snapshot: SnapshotDb)

--- a/app/src/main/java/com/scottyab/challenge/di/Modules.kt
+++ b/app/src/main/java/com/scottyab/challenge/di/Modules.kt
@@ -33,6 +33,7 @@ import com.scottyab.challenge.presentation.common.AppCoroutineScope
 import com.scottyab.challenge.presentation.common.CoilImageLoader
 import com.scottyab.challenge.presentation.common.ImageLoader
 import com.scottyab.challenge.presentation.common.SimpleThrottler
+import com.scottyab.challenge.presentation.details.DetailsViewModel
 import com.scottyab.challenge.presentation.snapshots.SnapshotUiMapper
 import com.scottyab.challenge.presentation.snapshots.SnapshotsViewModel
 import com.squareup.moshi.Moshi
@@ -45,144 +46,157 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-val appModule = module {
-    single<ImageLoader> { CoilImageLoader() }
-    single { AppCoroutineScope() }
-    single<AndroidResources> { AndroidResourcesProvider(androidContext()) }
-    factory { SimpleThrottler() }
-    single { androidContext().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
-    factory<LocationCalculator> { AndroidLocationCalculator() }
-}
-
-val networkModule = module {
-    single {
-        Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
+val appModule =
+    module {
+        single<ImageLoader> { CoilImageLoader() }
+        single { AppCoroutineScope() }
+        single<AndroidResources> { AndroidResourcesProvider(androidContext()) }
+        factory { SimpleThrottler() }
+        single { androidContext().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
+        factory<LocationCalculator> { AndroidLocationCalculator() }
     }
 
-    single {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                HttpLoggingInterceptor().apply {
-                    if (BuildConfig.DEBUG) {
-                        setLevel(HttpLoggingInterceptor.Level.BASIC)
+val networkModule =
+    module {
+        single {
+            Moshi.Builder()
+                .add(KotlinJsonAdapterFactory())
+                .build()
+        }
+
+        single {
+            OkHttpClient.Builder()
+                .addInterceptor(
+                    HttpLoggingInterceptor().apply {
+                        if (BuildConfig.DEBUG) {
+                            setLevel(HttpLoggingInterceptor.Level.BASIC)
+                        }
                     }
-                }
-            ).build()
-    }
+                ).build()
+        }
 
-    single<FlickrService> {
-        Retrofit.Builder()
-            .baseUrl(BuildConfig.FLICKR_BASE_URL)
-            .addConverterFactory(MoshiConverterFactory.create(get()))
-            .client(get())
-            .build()
-            .create(FlickrService::class.java)
-    }
-}
-
-val domainModule = module {
-    factory<IdGenerator> { UUIDGenerator() }
-    factory<ActivityNameGenerator> { TimeOfDayActivityNameGenerator() }
-
-    factory<SnapshotRepository> {
-        RealSnapshotRepository(
-            flickrService = get(),
-            snapshotMapper = get(),
-            snapshotDao = get(),
-            photoMapper = get()
-        )
-    }
-    factory { SnapshotMapper(idGenerator = get()) }
-    factory { PhotoMapper() }
-    factory { ActivityMapper() }
-
-    factory<ActivityRepository> {
-        RealActivityRepository(
-            activityMapper = get(),
-            activityDao = get(),
-            idGenerator = get()
-        )
-    }
-
-    factory {
-        NewLocationUsecase(
-            snapshotRepository = get(),
-            locationCalculator = get()
-        )
-    }
-
-    factory {
-        StopActivityUsecase(
-            activityRepository = get()
-        )
-    }
-
-    factory {
-        StartActivityUsecase(
-            activityNameGenerator = get(),
-            activityRepository = get()
-        )
-    }
-
-    single {
-        SnapshotTracker(
-            locationProvider = get(),
-            newLocationUsecase = get(),
-            startActivityUsecase = get(),
-            stopActivityUsecase = get(),
-            appCoroutineScope = get()
-        )
-    }
-}
-
-val dataModule = module {
-    single { TrackerDatabase.getInstance(androidContext()) }
-    factory { get<TrackerDatabase>().snapshotsDao() }
-    factory { get<TrackerDatabase>().activityDao() }
-
-    factory {
-        LocationServiceNotificationHelper(
-            context = androidContext(),
-            androidResources = get(),
-            notificationManager = get()
-        )
-    }
-    single {
-        RealLocationProvider(
-            context = androidContext(),
-            appCoroutineScope = get()
-        )
-    }
-
-    single<LocationProvider> {
-        if (BuildConfig.SAMPLE_LOCATIONS) {
-            SampleLocationProvider(
-                context = androidContext(),
-                moshi = get(),
-                appCoroutineScope = get()
-            )
-        } else {
-            get<RealLocationProvider>()
+        single<FlickrService> {
+            Retrofit.Builder()
+                .baseUrl(BuildConfig.FLICKR_BASE_URL)
+                .addConverterFactory(MoshiConverterFactory.create(get()))
+                .client(get())
+                .build()
+                .create(FlickrService::class.java)
         }
     }
-}
 
-val presentationModule = module {
-    factory { SnapshotUiMapper() }
-    viewModel {
-        SnapshotsViewModel(
-            snapshotRepository = get(),
-            snapshotUiMapper = get(),
-            snapshotTracker = get()
-        )
+val domainModule =
+    module {
+        factory<IdGenerator> { UUIDGenerator() }
+        factory<ActivityNameGenerator> { TimeOfDayActivityNameGenerator() }
+
+        factory<SnapshotRepository> {
+            RealSnapshotRepository(
+                flickrService = get(),
+                snapshotMapper = get(),
+                snapshotDao = get(),
+                photoMapper = get()
+            )
+        }
+        factory { SnapshotMapper(idGenerator = get()) }
+        factory { PhotoMapper() }
+        factory { ActivityMapper() }
+
+        factory<ActivityRepository> {
+            RealActivityRepository(
+                activityMapper = get(),
+                activityDao = get(),
+                idGenerator = get()
+            )
+        }
+
+        factory {
+            NewLocationUsecase(
+                snapshotRepository = get(),
+                locationCalculator = get()
+            )
+        }
+
+        factory {
+            StopActivityUsecase(
+                activityRepository = get()
+            )
+        }
+
+        factory {
+            StartActivityUsecase(
+                activityNameGenerator = get(),
+                activityRepository = get()
+            )
+        }
+
+        single {
+            SnapshotTracker(
+                locationProvider = get(),
+                newLocationUsecase = get(),
+                startActivityUsecase = get(),
+                stopActivityUsecase = get(),
+                appCoroutineScope = get()
+            )
+        }
     }
-    viewModel {
-        ActivitiesViewModel(
-            activityRepository = get()
-        )
+
+val dataModule =
+    module {
+        single { TrackerDatabase.getInstance(androidContext()) }
+        factory { get<TrackerDatabase>().snapshotsDao() }
+        factory { get<TrackerDatabase>().activityDao() }
+
+        factory {
+            LocationServiceNotificationHelper(
+                context = androidContext(),
+                androidResources = get(),
+                notificationManager = get()
+            )
+        }
+        single {
+            RealLocationProvider(
+                context = androidContext(),
+                appCoroutineScope = get()
+            )
+        }
+
+        single<LocationProvider> {
+            if (BuildConfig.SAMPLE_LOCATIONS) {
+                SampleLocationProvider(
+                    context = androidContext(),
+                    moshi = get(),
+                    appCoroutineScope = get()
+                )
+            } else {
+                get<RealLocationProvider>()
+            }
+        }
     }
-}
+
+val presentationModule =
+    module {
+        factory { SnapshotUiMapper() }
+        viewModel {
+            SnapshotsViewModel(
+                snapshotRepository = get(),
+                snapshotUiMapper = get(),
+                snapshotTracker = get()
+            )
+        }
+        viewModel {
+            ActivitiesViewModel(
+                activityRepository = get()
+            )
+        }
+
+        viewModel { (snapshotId: String) ->
+            DetailsViewModel(
+                snapshotRepository = get(),
+                snapshotUiMapper = get(),
+                snapshotId = snapshotId
+            )
+        }
+    }
 
 val allModules = listOf(appModule, networkModule, domainModule, dataModule, presentationModule)

--- a/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
+++ b/app/src/main/java/com/scottyab/challenge/domain/SnapshotRepository.kt
@@ -5,10 +5,14 @@ import com.scottyab.challenge.domain.model.Snapshot
 import kotlinx.coroutines.flow.Flow
 
 interface SnapshotRepository {
-
     fun getSnapshots(activityId: String): Flow<List<Snapshot>>
 
-    suspend fun addSnapshot(activityId: String, location: Location)
+    suspend fun addSnapshot(
+        activityId: String,
+        location: Location
+    )
+
+    suspend fun getSnapShot(snapshotId: String): Snapshot
 
     /** TODO remove this as it's not needed as we deal with this on the activity level **/
     suspend fun reset(activityId: String)

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsActivity.kt
@@ -1,0 +1,44 @@
+package com.scottyab.challenge.presentation.details
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.livedata.observeAsState
+import com.scottyab.challenge.presentation.ui.SampleAppTheme
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
+
+class DetailsActivity : ComponentActivity() {
+    private val viewModel: DetailsViewModel by viewModel {
+        parametersOf(intent.getStringExtra(EXTRA_SNAPSHOT_ID))
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val uiState = viewModel.state.observeAsState(DetailsState()).value
+
+            if (uiState.gotoSnapshots) {
+                finish()
+            }
+
+            SampleAppTheme {
+                DetailsScreen(uiState, viewModel::handleUiEvent)
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_SNAPSHOT_ID = "EXTRA_SNAPSHOT_ID"
+
+        private fun openIntent(context: Context) = Intent(context, DetailsActivity::class.java)
+
+        fun openIntentExisting(
+            context: Context,
+            snapshotId: String
+        ) = openIntent(context).putExtra(EXTRA_SNAPSHOT_ID, snapshotId)
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsScreen.kt
@@ -1,0 +1,159 @@
+package com.scottyab.challenge.presentation.details
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import com.scottyab.challenge.R
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.ShareClick
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.SnackMessageShown
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.UpClick
+import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
+import com.scottyab.challenge.presentation.ui.SampleAppTheme
+import com.scottyab.challenge.presentation.ui.common.AppProgressIndicator
+import com.scottyab.challenge.presentation.ui.common.DefaultTopBar
+import java.time.LocalDateTime
+
+@Suppress("ktlint:standard:function-naming")
+@Composable
+fun DetailsScreen(
+    uiState: DetailsState,
+    uiEventReceiver: (DetailsUiEvent) -> Unit
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            DefaultTopBar(
+                uiState.title,
+                onBackIconClick = { uiEventReceiver.invoke(UpClick) }
+            )
+        },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0)
+    ) { padding ->
+        if (uiState.showSnackMessage) {
+            LaunchedEffect(scope, uiState.snackMessage, snackbarHostState) {
+                val result =
+                    snackbarHostState.showSnackbar(
+                        message = uiState.snackMessage,
+                        duration = SnackbarDuration.Short
+                    )
+                when (result) {
+                    SnackbarResult.Dismissed -> uiEventReceiver.invoke(SnackMessageShown)
+                    SnackbarResult.ActionPerformed -> { // No-Op
+                    }
+                }
+            }
+        }
+
+        if (uiState.showLoading) {
+            AppProgressIndicator()
+        } else {
+            Column(
+                modifier =
+                Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+            ) {
+                Column(
+                    modifier =
+                    Modifier
+                        .verticalScroll(rememberScrollState())
+                        .weight(1f)
+                ) {
+                    // content goes here
+                    SnapShotDetailsComposable(
+                        snapshot = uiState.aSnapshot,
+                        shareClick = { uiEventReceiver.invoke(ShareClick(uiState.aSnapshot.imageUrl)) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SnapShotDetailsComposable(
+    snapshot: SnapshotUi,
+    shareClick: () -> Unit
+) {
+    Column(
+        modifier =
+        Modifier
+            .fillMaxSize()
+            .padding(4.dp)
+    ) {
+        SubcomposeAsyncImage(
+            model = snapshot.imageUrl,
+            contentDescription = stringResource(R.string.snapshot_image_cd),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        BasicText(text = snapshot.title, style = MaterialTheme.typography.headlineLarge)
+        BasicText(text = snapshot.recordedAtFormatted)
+        Button(
+            onClick = { shareClick.invoke() },
+            modifier =
+            Modifier
+                .padding(16.dp)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Share,
+                contentDescription = stringResource(R.string.details_share_button_cd)
+            )
+            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+            Text(stringResource(R.string.details_share_button))
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DetailsScreenPreview() {
+    val snapshotUi =
+        SnapshotUi(
+            id = "123",
+            title = "This is a title",
+            imageUrl = "",
+            recordedAt = LocalDateTime.now()
+        )
+    val uiState =
+        DetailsState(
+            aSnapshot = snapshotUi
+        )
+    SampleAppTheme {
+        DetailsScreen(uiState) {}
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/details/DetailsViewModel.kt
@@ -1,0 +1,63 @@
+package com.scottyab.challenge.presentation.details
+
+import androidx.lifecycle.viewModelScope
+import com.scottyab.challenge.domain.SnapshotRepository
+import com.scottyab.challenge.presentation.common.BaseViewModel
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.ShareClick
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.SnackMessageShown
+import com.scottyab.challenge.presentation.details.DetailsUiEvent.UpClick
+import com.scottyab.challenge.presentation.snapshots.SnapshotUiMapper
+import com.scottyab.challenge.presentation.snapshots.model.EMPTY_SNAPSHOT
+import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class DetailsViewModel(
+    private val snapshotRepository: SnapshotRepository,
+    private val snapshotUiMapper: SnapshotUiMapper,
+    private val snapshotId: String,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : BaseViewModel<DetailsState>(DetailsState()) {
+    init {
+        viewModelScope.launch {
+            val snapshot =
+                withContext(backgroundDispatcher) {
+                    snapshotUiMapper.toUi(snapshotRepository.getSnapShot(snapshotId))
+                }
+            setState { copy(aSnapshot = snapshot) }
+        }
+    }
+
+    fun handleUiEvent(detailsUiEvent: DetailsUiEvent) {
+        when (detailsUiEvent) {
+            is ShareClick -> handleShare(detailsUiEvent.url)
+            is SnackMessageShown -> setState { copy(snackMessage = "") }
+            is UpClick -> setState { copy(gotoSnapshots = true) }
+        }
+    }
+
+    private fun handleShare(url: String) {
+        setState { copy(snackMessage = "Sharing {$url}") }
+    }
+}
+
+data class DetailsState(
+    val aSnapshot: SnapshotUi = EMPTY_SNAPSHOT,
+    val showLoading: Boolean = false,
+    val snackMessage: String = "",
+    val gotoSnapshots: Boolean = false
+) {
+    val isEmpty = aSnapshot == EMPTY_SNAPSHOT
+    val title = if (isEmpty) "" else "Details"
+    val showSnackMessage = snackMessage.isNotEmpty()
+}
+
+sealed interface DetailsUiEvent {
+    data object UpClick : DetailsUiEvent
+
+    data object SnackMessageShown : DetailsUiEvent
+
+    data class ShareClick(val url: String) : DetailsUiEvent
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/snapshots/SnapshotsActivity.kt
@@ -13,16 +13,15 @@ import com.scottyab.challenge.databinding.ActivitySnapshotsListBinding
 import com.scottyab.challenge.presentation.common.ImageLoader
 import com.scottyab.challenge.presentation.common.SimpleThrottler
 import com.scottyab.challenge.presentation.common.action
-import com.scottyab.challenge.presentation.common.createShareIntent
 import com.scottyab.challenge.presentation.common.openAppSettings
 import com.scottyab.challenge.presentation.common.snack
 import com.scottyab.challenge.presentation.common.viewBinding
+import com.scottyab.challenge.presentation.details.DetailsActivity
 import com.scottyab.challenge.presentation.snapshots.model.SnapshotUi
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class SnapshotsActivity : AppCompatActivity() {
-
     private val binding by viewBinding(ActivitySnapshotsListBinding::inflate)
     private val imageLoader by inject<ImageLoader>()
     private val clickThrottler by inject<SimpleThrottler>()
@@ -30,19 +29,20 @@ class SnapshotsActivity : AppCompatActivity() {
 
     private lateinit var adapter: SnapshotAdapter
 
-    private val locationPermissionRequest = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-        when {
-            // todo more robust checking of all the permissions needed
-            permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
-                // request background location permission (needs to be a separate request)
-                checkBackgroundLocationPermission()
-            } else -> {
-                snack(getString(R.string.location_permission_denied_msg)) {
-                    action(getString(R.string.location_permission_denied_action)) { openAppSettings() }
+    private val locationPermissionRequest =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            when {
+                // todo more robust checking of all the permissions needed
+                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
+                    // request background location permission (needs to be a separate request)
+                    checkBackgroundLocationPermission()
+                } else -> {
+                    snack(getString(R.string.location_permission_denied_msg)) {
+                        action(getString(R.string.location_permission_denied_action)) { openAppSettings() }
+                    }
                 }
             }
         }
-    }
 
     private val backgroundPermissionRequest =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -75,10 +75,11 @@ class SnapshotsActivity : AppCompatActivity() {
     }
 
     private fun checkRequiredPermissions() {
-        val permissions = mutableListOf(
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION
-        )
+        val permissions =
+            mutableListOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             permissions.add(Manifest.permission.POST_NOTIFICATIONS)
@@ -95,29 +96,28 @@ class SnapshotsActivity : AppCompatActivity() {
         }
     }
 
-    private fun bindView(snapshots: List<SnapshotUi>, toggleButtonTextResId: Int) {
+    private fun bindView(
+        snapshots: List<SnapshotUi>,
+        toggleButtonTextResId: Int
+    ) {
         adapter.submitList(snapshots)
         binding.snapshotsRecyclerview.smoothScrollToPosition(0)
         binding.toolbar.menu.findItem(R.id.menu_toggle)?.title = getString(toggleButtonTextResId)
     }
 
     private fun initView() {
-        adapter = SnapshotAdapter(
-            imageLoader = imageLoader,
-            onItemClick = { snapshot ->
-                // This is added for demo purposes to show we could do something with onClick
-                // if this were real app this would be handled by VM or navigator
-                snack(snapshot.title) {
-                    action(getString(R.string.snapshot_share)) {
-                        startActivity(
-                            createShareIntent(
-                                getString(R.string.snapshot_share_text, snapshot.imageUrl)
-                            )
+        adapter =
+            SnapshotAdapter(
+                imageLoader = imageLoader,
+                onItemClick = { snapshot ->
+                    startActivity(
+                        DetailsActivity.openIntentExisting(
+                            context = this,
+                            snapshotId = snapshot.id
                         )
-                    }
+                    )
                 }
-            }
-        )
+            )
 
         binding.apply {
             setContentView(root)
@@ -139,14 +139,17 @@ class SnapshotsActivity : AppCompatActivity() {
 
         fun openIntent(context: Context) = Intent(context, SnapshotsActivity::class.java)
 
-        fun openIntentExisting(context: Context, activityId: String) =
-            openIntent(context).putExtra(EXTRA_ACTIVITY_ID, activityId)
+        fun openIntentExisting(
+            context: Context,
+            activityId: String
+        ) = openIntent(context).putExtra(EXTRA_ACTIVITY_ID, activityId)
 
-        fun openFromNotificationPendingIntent(context: Context) = PendingIntent.getActivity(
-            context,
-            OPEN_FROM_NOTIFICATION_RC,
-            openIntent(context),
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
+        fun openFromNotificationPendingIntent(context: Context) =
+            PendingIntent.getActivity(
+                context,
+                OPEN_FROM_NOTIFICATION_RC,
+                openIntent(context),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
     }
 }

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/Color.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/Color.kt
@@ -1,0 +1,12 @@
+package com.scottyab.challenge.presentation.ui
+
+import androidx.compose.ui.graphics.Color
+
+val AppBlue = Color(0xFF0A5787)
+val Secondary = Color(0xFF084A72)
+val VioletText = Color(0xFF140A97)
+val Grey200 = Color(0xFFF3F4F6)
+val Grey500 = Color(0xFF9A9A9A)
+val GreyText = Color(0xFF9A9A9A)
+val Black = Color(0xFF000000)
+val White = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/Theme.kt
@@ -1,0 +1,51 @@
+package com.scottyab.challenge.presentation.ui
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+private val SampleAppColorScheme =
+    lightColorScheme(
+        primary = AppBlue,
+        secondary = Secondary,
+        tertiary = VioletText,
+        background = Grey200,
+        surface = Secondary,
+        surfaceVariant = Grey200,
+        onPrimary = White,
+        onSecondary = White,
+        onTertiary = Black,
+        onBackground = Black,
+        onSurface = White
+    )
+
+@Composable
+fun SampleAppTheme(
+    colorScheme: ColorScheme = SampleAppColorScheme,
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography =
+        Typography(
+            labelLarge =
+            TextStyle(
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 24.sp
+            ),
+            titleLarge =
+            TextStyle(
+                fontSize = 19.sp,
+                fontWeight = FontWeight.W600,
+                lineHeight = 24.sp
+            )
+        ),
+        content = content
+    )
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/Loading.kt
@@ -1,0 +1,31 @@
+package com.scottyab.challenge.presentation.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AppProgressIndicator(
+    modifier: Modifier = Modifier,
+    progressContentDescription: String = "Loading"
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+        Modifier.fillMaxSize().semantics {
+            contentDescription = progressContentDescription
+        }
+    ) {
+        CircularProgressIndicator(
+            modifier = modifier.padding(8.dp).size(36.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
+++ b/app/src/main/java/com/scottyab/challenge/presentation/ui/common/TopBars.kt
@@ -1,0 +1,31 @@
+package com.scottyab.challenge.presentation.ui.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.scottyab.challenge.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DefaultTopBar(
+    titleText: String,
+    onBackIconClick: () -> Unit
+) {
+    TopAppBar(
+        title = { Text(titleText) },
+        modifier = Modifier.fillMaxWidth(),
+        navigationIcon = {
+            IconButton(onClick = { onBackIconClick.invoke() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = stringResource(id = R.string.back_button))
+            }
+        }
+    )
+}

--- a/app/src/main/res/drawable/placeholder.xml
+++ b/app/src/main/res/drawable/placeholder.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,5 +23,9 @@
     <string name="cd_new_activity">Start new Activity</string>
     <string name="activities_title">Recorded Activities</string>
     <string name="activities_empty_text">No activities recorded, tap the plus Icon to start recording a new Activity.</string>
+    <string name="back_button">Back</string>
+    <string name="details_share_button">Share</string>
+    <string name="details_share_button_cd">Share</string>
+    <string name="snapshot_image_cd">Snapshot Image</string>
 
 </resources>


### PR DESCRIPTION
Purpose of the PR is to showcase a simple UI built with Jetpack Compose. 

It adds a Details screen which is shown when tapping an item/snapshot from the list.

# Video Summary/Demo

📹  [Loom video](https://www.loom.com/share/90d908dbc4bf4f49bb8da485a93c45bf?sid=5a72d24c-7804-4a0b-b7b7-af8b029e8c76)

# Screen shot

![image](https://github.com/scottyab/sample-location-based-image-tracker/assets/404105/7cec541e-471b-4225-8fc0-1b383bc986a7)
   

